### PR TITLE
Add repository field to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0"
 keywords = ["future", "FuturesUnordered", "HashMap", "async", "stream"]
 categories = ["asynchronous"]
 description = "A collection of futures based on FuturesUnordered that supports insertion, removal and mutation of futures by key"
+repository = "https://github.com/StoicDeveloper/mapped_future"
 
 [dependencies]
 futures-core = "0.3.28"


### PR DESCRIPTION
So that `crates.io` and `docs.rs` point to the repository.